### PR TITLE
Fix typos and grammar issues in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ limitations under the License.
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_ja.md">日本語</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_hd.md">हिन्दी</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_ru.md">Русский</a> |
-        <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_pt-br.md">Рortuguês</a> |
+        <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_pt-br.md">Português</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_te.md">తెలుగు</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_fr.md">Français</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_de.md">Deutsch</a> |

--- a/docs/source/en/modular_transformers.md
+++ b/docs/source/en/modular_transformers.md
@@ -94,7 +94,7 @@ ValueError: You defined `RobertaEmbeddings` in the modular_roberta.py, it should
 
 ## Implementing a modular file
 
-The easiest way to start is by browsing Transformers for a model similar to yours in order to inherit from it. Some good starting points are [Mistral](./model_doc/mistral), [Qwen2](./model_doc/qwen2), [Cohere](./model_doc/cohere) and [Cohere](./model_doc/cohere2), and [Llama](./model_doc/llama). Refer to the table below for components your model might be using and where you can inherit from.
+The easiest way to start is by browsing Transformers for a model similar to yours in order to inherit from it. Some good starting points are [Mistral](./model_doc/mistral), [Qwen2](./model_doc/qwen2), [Cohere](./model_doc/cohere) and [Cohere2](./model_doc/cohere2), and [Llama](./model_doc/llama). Refer to the table below for components your model might be using and where you can inherit from.
 
 | Component | Model |
 |---|---|

--- a/docs/source/en/training.md
+++ b/docs/source/en/training.md
@@ -74,7 +74,7 @@ model = AutoModelForSequenceClassification.from_pretrained("google-bert/bert-bas
 ```
 
 > [!TIP]
-> The message above is a reminder that the models pretrained head is discarded and replaced with a randomly initialized classification head. The randomly initialized head needs to be fine-tuned on your specific task to output meanginful predictions.
+> The message above is a reminder that the models pretrained head is discarded and replaced with a randomly initialized classification head. The randomly initialized head needs to be fine-tuned on your specific task to output meaningful predictions.
 
 With the model loaded, set up your training hyperparameters in [`TrainingArguments`]. Hyperparameters are variables that control the training process - such as the learning rate, batch size, number of epochs - which in turn impacts model performance. Selecting the correct hyperparameters is important and you should experiment with them to find the best configuration for your task.
 

--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -426,7 +426,7 @@ class ChatCommand(BaseTransformersCLICommand):
         # 2. c. [no processing needed] lists are lists of ints because `generate` doesn't take lists of strings :)
         # We also mention in the help message that we only accept lists of ints for now.
 
-        # 3. Join the the result into a comma separated string
+        # 3. Join the result into a comma separated string
         generate_flags_string = ", ".join([f"{k}: {v}" for k, v in generate_flags_as_dict.items()])
 
         # 4. Add the opening/closing brackets

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -529,7 +529,7 @@ class Trainer:
                 kernel_config = self.args.liger_kernel_config if self.args.liger_kernel_config is not None else {}
 
                 if isinstance(model, PreTrainedModel):
-                    # Patch the model with liger kernels. Use the the specified or default kernel configurations.
+                    # Patch the model with liger kernels. Use the specified or default kernel configurations.
                     _apply_liger_kernel_to_instance(model=model, **kernel_config)
                 elif hasattr(model, "get_base_model") and isinstance(model.get_base_model(), PreTrainedModel):
                     # Patch the base model with liger kernels where model is a PeftModel. Use the specified or default kernel configurations.


### PR DESCRIPTION
## Summary
- Fixed Cyrillic 'Р' to Latin 'P' in Portuguese language link (README.md)
- Fixed 'meanginful' to 'meaningful' in training documentation
- Fixed duplicate 'Cohere' reference in modular transformers documentation  
- Fixed duplicate 'the the' in trainer and chat command comments

## Test plan
- [x] Verified all typos are corrected
- [x] Ensured no functional changes to code behavior
- [x] Maintained existing formatting and structure

🤖 Generated with [Claude Code](https://claude.ai/code)